### PR TITLE
feat: forward fill commodities to daily

### DIFF
--- a/data_pipeline/extract/extract_commodities.py
+++ b/data_pipeline/extract/extract_commodities.py
@@ -5,7 +5,7 @@ Extract commodities data from Alpha Vantage API and load into database.
 import os
 import sys
 import time
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import pandas as pd
@@ -52,8 +52,8 @@ class CommoditiesExtractor:
     def get_existing_data_dates_with_db(self, db, commodity_name, interval):
         """Get existing dates for a commodity to avoid duplicates using provided database connection."""
         query = """
-            SELECT date 
-            FROM commodities 
+            SELECT date
+            FROM commodities
             WHERE commodity_name = %s AND interval = %s AND api_response_status = 'data'
             ORDER BY date DESC
         """
@@ -64,8 +64,8 @@ class CommoditiesExtractor:
         """Get existing dates for a commodity to avoid duplicates."""
         with self.db_manager as db:
             query = """
-                SELECT date 
-                FROM commodities 
+                SELECT date
+                FROM commodities
                 WHERE commodity_name = %s AND interval = %s AND api_response_status = 'data'
                 ORDER BY date DESC
             """
@@ -75,8 +75,8 @@ class CommoditiesExtractor:
     def get_last_update_date_with_db(self, db, commodity_name, interval):
         """Get the most recent date for a commodity using provided database connection."""
         query = """
-            SELECT MAX(date) 
-            FROM commodities 
+            SELECT MAX(date)
+            FROM commodities
             WHERE commodity_name = %s AND interval = %s AND api_response_status = 'data'
         """
         result = db.fetch_query(query, (commodity_name, interval))
@@ -86,14 +86,14 @@ class CommoditiesExtractor:
         """Get the most recent date for a commodity."""
         with self.db_manager as db:
             query = """
-                SELECT MAX(date) 
-                FROM commodities 
+                SELECT MAX(date)
+                FROM commodities
                 WHERE commodity_name = %s AND interval = %s AND api_response_status = 'data'
             """
             result = db.fetch_query(query, (commodity_name, interval))
             return result[0][0] if result and result[0] and result[0][0] else None
 
-    def extract_commodity_data(self, function_name):
+    def extract_commodity_data(self, function_name):  # noqa: PLR0911
         """Extract data for a single commodity from Alpha Vantage API."""
         interval, display_name = COMMODITY_CONFIGS[function_name]
 
@@ -166,7 +166,7 @@ class CommoditiesExtractor:
             return None, "error", error_msg
 
     def load_commodity_data_with_db(
-        self, db, df, commodity_name, function_name, interval
+        self, db, df, commodity_name, _function_name, interval
     ):
         """Load commodity data into the database using provided database connection."""
         if df is None or df.empty:
@@ -213,7 +213,7 @@ class CommoditiesExtractor:
             db.initialize_schema(schema_path)
 
         insert_query = """
-            INSERT INTO commodities 
+            INSERT INTO commodities
             (commodity_name, function_name, date, interval, unit, value, name, api_response_status)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (commodity_name, date, interval) DO NOTHING
@@ -223,7 +223,7 @@ class CommoditiesExtractor:
         print(f"Inserted {inserted_count} new records for {commodity_name}")
         return inserted_count
 
-    def load_commodity_data(self, df, commodity_name, function_name, interval):
+    def load_commodity_data(self, df, commodity_name, _function_name, interval):
         """Load commodity data into the database."""
         if df is None or df.empty:
             return 0
@@ -269,7 +269,7 @@ class CommoditiesExtractor:
                 db.initialize_schema(schema_path)
 
             insert_query = """
-                INSERT INTO commodities 
+                INSERT INTO commodities
                 (commodity_name, function_name, date, interval, unit, value, name, api_response_status)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (commodity_name, date, interval) DO NOTHING
@@ -280,9 +280,9 @@ class CommoditiesExtractor:
         print(f"Inserted {inserted_count} new records for {commodity_name}")
         return inserted_count
 
-    def record_status_with_db(
+    def record_status_with_db(  # noqa: PLR0913
         self, db, commodity_name, function_name, interval, status, message
-    ):
+    ) -> None:
         """Record extraction status (empty/error/pass) in database using provided database connection."""
         # Initialize schema if tables don't exist
         schema_path = (
@@ -297,8 +297,8 @@ class CommoditiesExtractor:
 
         # Check if status record already exists
         check_query = """
-            SELECT commodity_id FROM commodities 
-            WHERE commodity_name = %s AND function_name = %s AND interval = %s 
+            SELECT commodity_id FROM commodities
+            WHERE commodity_name = %s AND function_name = %s AND interval = %s
             AND api_response_status = %s AND date IS NULL
         """
         existing = db.fetch_query(
@@ -311,7 +311,7 @@ class CommoditiesExtractor:
 
         # Insert status record
         insert_query = """
-            INSERT INTO commodities 
+            INSERT INTO commodities
             (commodity_name, function_name, date, interval, unit, value, name, api_response_status)
             VALUES (%s, %s, NULL, %s, NULL, NULL, %s, %s)
         """
@@ -337,8 +337,8 @@ class CommoditiesExtractor:
 
             # Check if status record already exists
             check_query = """
-                SELECT commodity_id FROM commodities 
-                WHERE commodity_name = %s AND function_name = %s AND interval = %s 
+                SELECT commodity_id FROM commodities
+                WHERE commodity_name = %s AND function_name = %s AND interval = %s
                 AND api_response_status = %s AND date IS NULL
             """
             existing = db.fetch_query(
@@ -351,7 +351,7 @@ class CommoditiesExtractor:
 
             # Insert status record
             insert_query = """
-                INSERT INTO commodities 
+                INSERT INTO commodities
                 (commodity_name, function_name, date, interval, unit, value, name, api_response_status)
                 VALUES (%s, %s, NULL, %s, NULL, NULL, %s, %s)
             """
@@ -480,6 +480,276 @@ class CommoditiesExtractor:
 
         return total_inserted, status_summary
 
+    def create_daily_table_if_not_exists(self, db):
+        """Create the commodities_daily table if it doesn't exist."""
+        if not db.table_exists("commodities_daily", schema_name="extracted"):
+            create_table_sql = """
+                CREATE TABLE IF NOT EXISTS extracted.commodities_daily (
+                    daily_commodity_id       SERIAL PRIMARY KEY,
+                    commodity_name           VARCHAR(100) NOT NULL,
+                    function_name            VARCHAR(50) NOT NULL,
+                    date                     DATE NOT NULL,
+                    original_interval        VARCHAR(15) NOT NULL CHECK (original_interval IN ('daily','monthly','quarterly')),
+                    updated_interval         VARCHAR(15) NOT NULL DEFAULT 'daily',
+                    unit                     VARCHAR(50),
+                    value                    NUMERIC(15,6),
+                    name                     VARCHAR(255),
+                    is_forward_filled        BOOLEAN DEFAULT FALSE,
+                    original_date            DATE,
+                    created_at               TIMESTAMP DEFAULT NOW(),
+                    updated_at               TIMESTAMP DEFAULT NOW(),
+                    UNIQUE(commodity_name, function_name, date)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_commodities_daily_name ON extracted.commodities_daily(commodity_name);
+                CREATE INDEX IF NOT EXISTS idx_commodities_daily_date ON extracted.commodities_daily(date);
+                CREATE INDEX IF NOT EXISTS idx_commodities_daily_interval ON extracted.commodities_daily(original_interval);
+                CREATE INDEX IF NOT EXISTS idx_commodities_daily_forward_filled ON extracted.commodities_daily(is_forward_filled);
+            """
+            db.execute_query(create_table_sql)
+            print("Created extracted.commodities_daily table")
+
+    def transform_to_daily_data(  # noqa: C901, PLR0912, PLR0915
+        self, db, force_update=False
+    ):
+        """Transform all commodities data to daily frequency using forward filling."""
+        print("\nStarting daily transformation of commodities...")
+
+        # Create the daily table if it doesn't exist
+        self.create_daily_table_if_not_exists(db)
+
+        # Get all data records from the main commodities table
+        query = """
+            SELECT commodity_name, function_name, date, interval as original_interval,
+                   unit, value, name
+            FROM commodities
+            WHERE api_response_status = 'data' AND date IS NOT NULL
+            ORDER BY commodity_name, function_name, date
+        """
+        source_data = db.fetch_query(query)
+        if not source_data:
+            print("No source data found for transformation")
+            return 0
+
+        print(f"Found {len(source_data)} source records to transform")
+
+        df = pd.DataFrame(
+            source_data,
+            columns=[
+                "commodity_name",
+                "function_name",
+                "date",
+                "original_interval",
+                "unit",
+                "value",
+                "name",
+            ],
+        )
+        df["date"] = pd.to_datetime(df["date"])
+
+        total_inserted = 0
+
+        for (commodity_name, function_name), group in df.groupby(
+            ["commodity_name", "function_name"]
+        ):
+            try:
+                if force_update:
+                    delete_query = """
+                        DELETE FROM extracted.commodities_daily
+                        WHERE commodity_name = %s AND function_name = %s
+                    """
+                    db.execute_query(delete_query, (commodity_name, function_name))
+
+                group_df = group.sort_values("date")
+                original_interval = group_df["original_interval"].iloc[0]
+                unit = group_df["unit"].iloc[0]
+                name = group_df["name"].iloc[0]
+
+                if original_interval == "daily":
+                    records = []
+                    for _, row in group_df.iterrows():
+                        records.append(
+                            (
+                                commodity_name,
+                                function_name,
+                                row["date"].date(),
+                                original_interval,
+                                "daily",
+                                unit,
+                                row["value"],
+                                name,
+                                False,
+                                row["date"].date(),
+                            )
+                        )
+                    print(f"  Daily data: {len(records)} records")
+
+                elif original_interval in ["monthly", "quarterly"]:
+                    records = []
+                    start_date = group_df["date"].min().date()
+                    end_date = date.today()
+                    print(
+                        f"  {original_interval.title()} data: Forward filling from {start_date} to {end_date}"
+                    )
+                    date_range = pd.date_range(start=start_date, end=end_date, freq="D")
+                    current_value = None
+                    current_original_date = None
+                    for current_ts in date_range:
+                        current_date = current_ts.date()
+                        matching_rows = group_df[
+                            group_df["date"].dt.date == current_date
+                        ]
+                        if not matching_rows.empty:
+                            current_value = matching_rows.iloc[0]["value"]
+                            current_original_date = current_date
+                            is_forward_filled = False
+                        else:
+                            is_forward_filled = current_value is not None
+                        if current_value is not None:
+                            records.append(
+                                (
+                                    commodity_name,
+                                    function_name,
+                                    current_date,
+                                    original_interval,
+                                    "daily",
+                                    unit,
+                                    current_value,
+                                    name,
+                                    is_forward_filled,
+                                    current_original_date,
+                                )
+                            )
+                    print(
+                        f"  {original_interval.title()} data: {len(records)} daily records (forward-filled from {len(group_df)} original records)"
+                    )
+
+                else:
+                    print(
+                        f"  Unsupported interval {original_interval} for {commodity_name}, skipping"
+                    )
+                    continue
+
+                if records:
+                    insert_query = """
+                        INSERT INTO extracted.commodities_daily
+                        (commodity_name, function_name, date, original_interval,
+                         updated_interval, unit, value, name, is_forward_filled, original_date)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (commodity_name, function_name, date)
+                        DO UPDATE SET
+                            original_interval = EXCLUDED.original_interval,
+                            updated_interval = EXCLUDED.updated_interval,
+                            unit = EXCLUDED.unit,
+                            value = EXCLUDED.value,
+                            name = EXCLUDED.name,
+                            is_forward_filled = EXCLUDED.is_forward_filled,
+                            original_date = EXCLUDED.original_date,
+                            updated_at = NOW()
+                    """
+                    inserted_count = db.execute_many(insert_query, records)
+                    total_inserted += inserted_count
+                    print(f"  Inserted {inserted_count} daily records")
+                else:
+                    print(f"  No records to insert for {commodity_name}")
+
+            except Exception as e:
+                print(f"  ERROR processing {commodity_name}: {str(e)}")
+                continue
+
+        print(
+            f"\nDaily transformation completed: {total_inserted} total records inserted"
+        )
+        return total_inserted
+
+    def run_etl_with_daily_transform(
+        self,
+        commodity_list=None,
+        batch_size=5,
+        force_update=False,
+        transform_to_daily=True,
+    ):
+        """Run ETL for commodities and optionally transform to daily data."""
+        print("Starting commodities ETL with daily transformation...")
+
+        daily_inserted = 0
+        with self.db_manager as db:
+            total_inserted, status_summary = self.run_etl_batch_with_db(
+                db, commodity_list, batch_size, force_update
+            )
+
+            if transform_to_daily:
+                daily_inserted = self.transform_to_daily_data(db, force_update)
+
+        print("\nTotal ETL Summary:")
+        print(f"  Original data inserted: {total_inserted}")
+        print(f"  Daily records inserted: {daily_inserted}")
+        print("Status breakdown:")
+        for status, count in status_summary.items():
+            print(f"  - {status}: {count}")
+
+        return total_inserted, status_summary, daily_inserted
+
+    def run_etl_batch_with_db(
+        self, db, commodity_list=None, batch_size=5, force_update=False
+    ):
+        """Run ETL for multiple commodities using provided database connection."""
+        if commodity_list is None:
+            commodity_list = list(COMMODITY_CONFIGS.keys())
+
+        print(f"Starting commodities ETL for {len(commodity_list)} commodities...")
+        print(f"Batch size: {batch_size}, Force update: {force_update}")
+        print("-" * 50)
+
+        total_inserted = 0
+        status_summary = {"data": 0, "empty": 0, "error": 0, "pass": 0}
+
+        for i, function_name in enumerate(commodity_list):
+            if function_name not in COMMODITY_CONFIGS:
+                print(f"Unknown commodity function: {function_name}")
+                continue
+
+            display_name = COMMODITY_CONFIGS[function_name][1]
+            print(f"Processing {i+1}/{len(commodity_list)}: {display_name}")
+
+            try:
+                inserted_count, status = self.extract_and_load_commodity_with_db(
+                    db, function_name, force_update
+                )
+                total_inserted += inserted_count
+                status_summary[status] += 1
+
+                if i < len(commodity_list) - 1:
+                    print(
+                        f"Rate limiting: sleeping for {self.rate_limit_delay} seconds..."
+                    )
+                    time.sleep(self.rate_limit_delay)
+
+                if (i + 1) % batch_size == 0 and i < len(commodity_list) - 1:
+                    print(
+                        f"Batch {(i + 1) // batch_size} completed. Pausing for 0.8 seconds..."
+                    )
+                    time.sleep(0.8)
+
+            except Exception as e:
+                print(f"Error processing {display_name}: {str(e)}")
+                status_summary["error"] += 1
+                continue
+
+            print("-" * 30)
+
+        print("\n" + "=" * 50)
+        print("COMMODITIES ETL SUMMARY")
+        print("=" * 50)
+        print(f"Total commodities processed: {len(commodity_list)}")
+        print(f"Total records inserted: {total_inserted}")
+        print("Status breakdown:")
+        for status, count in status_summary.items():
+            print(f"  - {status}: {count}")
+        print("=" * 50)
+
+        return total_inserted, status_summary
+
     def run_etl_update(self, commodity_list=None, batch_size=5):
         """Run ETL update to refresh latest data for commodities."""
         print("Running COMMODITIES UPDATE ETL...")
@@ -487,14 +757,13 @@ class CommoditiesExtractor:
 
     def get_commodities_needing_update(self, days_threshold=1):
         """Get list of commodities that need updates based on last update date."""
-        from datetime import timedelta
 
         threshold_date = datetime.now().date() - timedelta(days=days_threshold)
 
         with self.db_manager as db:
             query = """
                 SELECT DISTINCT commodity_name, function_name, MAX(date) as last_date
-                FROM commodities 
+                FROM commodities
                 WHERE api_response_status = 'data'
                 GROUP BY commodity_name, function_name
                 HAVING last_date IS NULL OR last_date <= %s
@@ -506,7 +775,7 @@ class CommoditiesExtractor:
                 for row in result:
                     # Find the function name for this commodity
                     for func_name, (
-                        interval,
+                        _interval,
                         display_name,
                     ) in COMMODITY_CONFIGS.items():
                         if display_name == row[0]:
@@ -535,7 +804,7 @@ class CommoditiesExtractor:
             # Total records by status
             status_query = """
                 SELECT api_response_status, COUNT(*) as count
-                FROM commodities 
+                FROM commodities
                 GROUP BY api_response_status
                 ORDER BY api_response_status
             """
@@ -544,7 +813,7 @@ class CommoditiesExtractor:
             # Data records by commodity
             commodity_query = """
                 SELECT commodity_name, interval, COUNT(*) as count, MIN(date) as earliest, MAX(date) as latest
-                FROM commodities 
+                FROM commodities
                 WHERE api_response_status = 'data'
                 GROUP BY commodity_name, interval
                 ORDER BY commodity_name, interval
@@ -557,11 +826,11 @@ class CommoditiesExtractor:
                 FROM commodities c1
                 INNER JOIN (
                     SELECT commodity_name, interval, MAX(date) as max_date
-                    FROM commodities 
+                    FROM commodities
                     WHERE api_response_status = 'data'
                     GROUP BY commodity_name, interval
-                ) c2 ON c1.commodity_name = c2.commodity_name 
-                     AND c1.interval = c2.interval 
+                ) c2 ON c1.commodity_name = c2.commodity_name
+                     AND c1.interval = c2.interval
                      AND c1.date = c2.max_date
                 ORDER BY c1.commodity_name, c1.interval
             """
@@ -624,8 +893,8 @@ def main():
     # agriculture_commodities = ['WHEAT', 'CORN', 'COTTON', 'SUGAR', 'COFFEE']
     # extractor.run_etl_batch(agriculture_commodities, batch_size=3, force_update=False)
 
-    # Option 5: Extract all commodities (full dataset)
-    extractor.run_etl_batch(force_update=False)  # Uses all commodities by default
+    # Option 5: Extract all commodities (full dataset) and transform to daily
+    extractor.run_etl_with_daily_transform(force_update=False)
 
     # === DATA UPDATES ===
     # Option 6: Update all commodities with fresh data (use sparingly due to API limits)


### PR DESCRIPTION
## Summary
- build daily commodities table and forward-fill monthly or quarterly values
- add utility to run ETL and daily transformation together
- update main script to transform to daily after extraction

## Testing
- `ruff check data_pipeline/extract/extract_commodities.py`
- `black data_pipeline/extract/extract_commodities.py`
- `python -m pytest` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f04b030832b8cf54d7fab1c5646