### PR TITLE
docs: add Alpha Vantage API data table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@
 
 <br>
 
+# Alpha Vantage API
+
+| Frequency | Source | Size |
+|-----------|----------------------------|------|
+| Quarterly | cash flow | M |
+| Quarterly | income statement | M |
+| Quarterly | balance sheet | M |
+| Quarterly | earnings call transcripts | L |
+| Varied | insider transactions | S |
+| Varied | news stories | L |
+| Daily | commodities | S |
+| Daily | economic indicators | S |
+| Daily | OHLCV | L |
+
 # Directory Structure
 
 ```graphql


### PR DESCRIPTION
## Summary
- document Alpha Vantage data sources with frequency and size table

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'db')*

------
https://chatgpt.com/codex/tasks/task_e_6890d6291dac832ba1b503c29bafe7d4