### PR TITLE
Fix UTC load timestamp compatibility

### DIFF
--- a/data_pipeline/transform/transform_load_symbol_universe.py
+++ b/data_pipeline/transform/transform_load_symbol_universe.py
@@ -38,7 +38,7 @@ import argparse
 import sys
 import uuid
 from collections.abc import Iterable, Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -121,7 +121,7 @@ def load_symbol_universe(
         raise ValueError(f"Input data missing required columns: {missing}")
 
     universe_id = uuid.uuid4()
-    load_time = datetime.now(datetime.UTC)
+    load_time = datetime.now(timezone.utc)  # noqa: UP017
 
     db = PostgresDatabaseManager()
     db.connect()


### PR DESCRIPTION
## Summary
- ensure `load_symbol_universe` uses `timezone.utc` instead of `datetime.UTC`
- import `timezone` from `datetime` and ignore lint rule UP017

## Testing
- `python -m ruff check data_pipeline/transform/transform_load_symbol_universe.py`
- `python -m black data_pipeline/transform/transform_load_symbol_universe.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'data_pipeline' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4997790832bb811fd6469aeeb35